### PR TITLE
feat(recurrence): add recurrence engine (#4)

### DIFF
--- a/lib/core/recurrence/frequency.dart
+++ b/lib/core/recurrence/frequency.dart
@@ -1,0 +1,10 @@
+enum Frequency {
+  daily,
+  weekly,
+  biWeekly,
+  monthly,
+  biMonthly,
+  quarterly,
+  semiAnnually,
+  annually,
+}

--- a/lib/core/recurrence/recurrence_engine.dart
+++ b/lib/core/recurrence/recurrence_engine.dart
@@ -1,0 +1,59 @@
+import 'frequency.dart';
+
+List<DateTime> computeDueDates({
+  required DateTime startDate,
+  required Frequency frequency,
+  DateTime? endDate,
+  required DateTime rangeStart,
+  required DateTime rangeEnd,
+}) {
+  startDate = _dateOnly(startDate);
+  rangeStart = _dateOnly(rangeStart);
+  rangeEnd = _dateOnly(rangeEnd);
+  if (endDate != null) endDate = _dateOnly(endDate);
+
+  if (startDate.isAfter(rangeEnd)) return [];
+  if (endDate != null && endDate.isBefore(rangeStart)) return [];
+
+  final effectiveEnd = endDate != null
+      ? (endDate.isBefore(rangeEnd) ? endDate : rangeEnd)
+      : rangeEnd;
+
+  final results = <DateTime>[];
+  var step = 0;
+
+  while (true) {
+    final current = _nthOccurrence(startDate, frequency, step);
+    if (current.isAfter(effectiveEnd)) break;
+    if (!current.isBefore(rangeStart)) results.add(current);
+    step++;
+  }
+
+  return results;
+}
+
+DateTime _nthOccurrence(DateTime start, Frequency freq, int n) {
+  return switch (freq) {
+    Frequency.daily => start.add(Duration(days: n)),
+    Frequency.weekly => start.add(Duration(days: 7 * n)),
+    Frequency.biWeekly => start.add(Duration(days: 14 * n)),
+    Frequency.monthly => _addMonths(start, n),
+    Frequency.biMonthly => _addMonths(start, 2 * n),
+    Frequency.quarterly => _addMonths(start, 3 * n),
+    Frequency.semiAnnually => _addMonths(start, 6 * n),
+    Frequency.annually => _addMonths(start, 12 * n),
+  };
+}
+
+DateTime _addMonths(DateTime date, int months) {
+  final targetMonth = date.month + months;
+  final year = date.year + (targetMonth - 1) ~/ 12;
+  final month = (targetMonth - 1) % 12 + 1;
+  final lastDay = _daysInMonth(year, month);
+  final day = date.day > lastDay ? lastDay : date.day;
+  return DateTime(year, month, day);
+}
+
+int _daysInMonth(int year, int month) => DateTime(year, month + 1, 0).day;
+
+DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);

--- a/test/core/recurrence/recurrence_engine_test.dart
+++ b/test/core/recurrence/recurrence_engine_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:folio/core/recurrence/frequency.dart';
+import 'package:folio/core/recurrence/recurrence_engine.dart';
+
+void main() {
+  group('computeDueDates', () {
+    final jan1 = DateTime(2025, 1, 1);
+    final jan31 = DateTime(2025, 1, 31);
+
+    test('daily returns every day in range', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.daily,
+        rangeStart: DateTime(2025, 1, 3),
+        rangeEnd: DateTime(2025, 1, 5),
+      );
+      expect(dates, [DateTime(2025, 1, 3), DateTime(2025, 1, 4), DateTime(2025, 1, 5)]);
+    });
+
+    test('weekly returns correct dates', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.weekly,
+        rangeStart: DateTime(2025, 1, 1),
+        rangeEnd: DateTime(2025, 1, 22),
+      );
+      expect(dates, [jan1, DateTime(2025, 1, 8), DateTime(2025, 1, 15), DateTime(2025, 1, 22)]);
+    });
+
+    test('biWeekly returns every 2 weeks', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.biWeekly,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 1, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 1, 15), DateTime(2025, 1, 29)]);
+    });
+
+    test('monthly returns same day each month', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.monthly,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 3, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 2, 1), DateTime(2025, 3, 1)]);
+    });
+
+    test('monthly clamps day for short months (Jan 31 -> Feb 28)', () {
+      final dates = computeDueDates(
+        startDate: jan31,
+        frequency: Frequency.monthly,
+        rangeStart: jan31,
+        rangeEnd: DateTime(2025, 3, 31),
+      );
+      expect(dates, [jan31, DateTime(2025, 2, 28), DateTime(2025, 3, 31)]);
+    });
+
+    test('biMonthly returns every 2 months', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.biMonthly,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 5, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 3, 1), DateTime(2025, 5, 1)]);
+    });
+
+    test('quarterly returns every 3 months', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.quarterly,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 7, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 4, 1), DateTime(2025, 7, 1)]);
+    });
+
+    test('semiAnnually returns every 6 months', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.semiAnnually,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 12, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 7, 1)]);
+    });
+
+    test('annually returns same day next year', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.annually,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2026, 1, 31),
+      );
+      expect(dates, [jan1, DateTime(2026, 1, 1)]);
+    });
+
+    test('respects endDate — no dates after it', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.monthly,
+        endDate: DateTime(2025, 2, 15),
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 3, 31),
+      );
+      expect(dates, [jan1, DateTime(2025, 2, 1)]);
+    });
+
+    test('returns empty when startDate is after rangeEnd', () {
+      final dates = computeDueDates(
+        startDate: DateTime(2025, 4, 1),
+        frequency: Frequency.monthly,
+        rangeStart: jan1,
+        rangeEnd: DateTime(2025, 3, 31),
+      );
+      expect(dates, isEmpty);
+    });
+
+    test('returns empty when endDate is before rangeStart', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.monthly,
+        endDate: DateTime(2024, 12, 31),
+        rangeStart: DateTime(2025, 1, 1),
+        rangeEnd: DateTime(2025, 3, 31),
+      );
+      expect(dates, isEmpty);
+    });
+
+    test('same-day start is included when in range', () {
+      final dates = computeDueDates(
+        startDate: jan1,
+        frequency: Frequency.monthly,
+        rangeStart: jan1,
+        rangeEnd: jan1,
+      );
+      expect(dates, [jan1]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Added `Frequency` enum with 8 values (daily, weekly, biWeekly, monthly, biMonthly, quarterly, semiAnnually, annually)
- Added `computeDueDates()` pure Dart function in `lib/core/recurrence/`
- Handles all 8 frequencies, optional endDate clipping, and last-day-of-month roll-over for monthly frequencies
- 13 unit tests covering all acceptance criteria

## Closes

Closes #4

## Test plan

- [ ] `flutter test test/core/recurrence/recurrence_engine_test.dart` — all 13 tests pass
- [ ] No Flutter or database imports in the recurrence module