### PR TITLE
feat(onboarding): first-launch wizard for currency and frequency (#5)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,9 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:folio/core/router/router.dart';
-import 'package:folio/core/theme/app_theme.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'core/providers/settings_providers.dart';
+import 'core/router/router.dart';
+import 'core/theme/app_theme.dart';
 
-class App extends StatelessWidget {
+class App extends ConsumerStatefulWidget {
   const App({super.key});
+
+  @override
+  ConsumerState<App> createState() => _AppState();
+}
+
+class _AppState extends ConsumerState<App> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(settingsRepositoryProvider).load();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +25,7 @@ class App extends StatelessWidget {
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
       themeMode: ThemeMode.system,
-      routerConfig: router,
+      routerConfig: ref.watch(routerProvider),
     );
   }
 }

--- a/lib/core/providers/settings_providers.dart
+++ b/lib/core/providers/settings_providers.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../settings/settings_repository.dart';
+import 'database_providers.dart';
+
+final settingsRepositoryProvider = ChangeNotifierProvider<SettingsRepository>((ref) {
+  return SettingsRepository(ref.watch(appSettingsDaoProvider));
+});

--- a/lib/core/recurrence/frequency.dart
+++ b/lib/core/recurrence/frequency.dart
@@ -8,3 +8,16 @@ enum Frequency {
   semiAnnually,
   annually,
 }
+
+extension FrequencyLabel on Frequency {
+  String get label => switch (this) {
+    Frequency.daily => 'Every day',
+    Frequency.weekly => 'Every week',
+    Frequency.biWeekly => 'Every 2 weeks',
+    Frequency.monthly => 'Every month',
+    Frequency.biMonthly => 'Every 2 months',
+    Frequency.quarterly => 'Every 3 months',
+    Frequency.semiAnnually => 'Every 6 months',
+    Frequency.annually => 'Every year',
+  };
+}

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -1,41 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:folio/features/calendar/calendar_screen.dart';
-import 'package:folio/features/summary/summary_screen.dart';
-import 'package:folio/features/settings/settings_screen.dart';
-import 'package:folio/shared/widgets/scaffold_with_nav.dart';
+import '../providers/settings_providers.dart';
+import '../../features/calendar/calendar_screen.dart';
+import '../../features/onboarding/onboarding_screen.dart';
+import '../../features/settings/settings_screen.dart';
+import '../../features/summary/summary_screen.dart';
+import '../../shared/widgets/scaffold_with_nav.dart';
 
-final router = GoRouter(
-  initialLocation: '/calendar',
-  routes: [
-    StatefulShellRoute.indexedStack(
-      builder: (context, state, navigationShell) =>
-          ScaffoldWithNav(navigationShell: navigationShell),
-      branches: [
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/calendar',
-              builder: (context, state) => const CalendarScreen(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/summary',
-              builder: (context, state) => const SummaryScreen(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/settings',
-              builder: (context, state) => const SettingsScreen(),
-            ),
-          ],
-        ),
-      ],
-    ),
-  ],
-);
+final routerProvider = Provider<GoRouter>((ref) {
+  final settings = ref.read(settingsRepositoryProvider);
+  return GoRouter(
+    initialLocation: '/calendar',
+    refreshListenable: settings,
+    redirect: (context, state) {
+      if (settings.onboardingComplete == null) return null;
+      final onOnboarding = state.matchedLocation.startsWith('/onboarding');
+      if (!settings.onboardingComplete! && !onOnboarding) return '/onboarding';
+      if (settings.onboardingComplete! && onOnboarding) return '/calendar';
+      return null;
+    },
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        builder: (context, state) => const OnboardingScreen(),
+      ),
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) =>
+            ScaffoldWithNav(navigationShell: navigationShell),
+        branches: [
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/calendar', builder: (_, __) => const CalendarScreen()),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/summary', builder: (_, __) => const SummaryScreen()),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
+          ]),
+        ],
+      ),
+    ],
+  );
+});

--- a/lib/core/settings/settings_repository.dart
+++ b/lib/core/settings/settings_repository.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+import '../recurrence/frequency.dart';
+import '../../data/database/app_database.dart';
+
+class SettingsRepository extends ChangeNotifier {
+  final AppSettingsDao _dao;
+
+  bool? _onboardingComplete;
+  String _currency = 'GBP';
+  Frequency _defaultFrequency = Frequency.monthly;
+
+  SettingsRepository(this._dao);
+
+  bool? get onboardingComplete => _onboardingComplete;
+  String get currency => _currency;
+  Frequency get defaultFrequency => _defaultFrequency;
+
+  Future<void> load() async {
+    final flag = await _dao.getValue('onboarding_complete');
+    _onboardingComplete = flag == 'true';
+    _currency = await _dao.getValue('currency') ?? 'GBP';
+    final freqStr = await _dao.getValue('default_frequency');
+    _defaultFrequency = freqStr != null
+        ? Frequency.values.byName(freqStr)
+        : Frequency.monthly;
+    notifyListeners();
+  }
+
+  Future<void> completeOnboarding({
+    required String currency,
+    required Frequency defaultFrequency,
+  }) async {
+    await _dao.setValue('currency', currency);
+    await _dao.setValue('default_frequency', defaultFrequency.name);
+    await _dao.setValue('onboarding_complete', 'true');
+    _onboardingComplete = true;
+    _currency = currency;
+    _defaultFrequency = defaultFrequency;
+    notifyListeners();
+  }
+}

--- a/lib/data/database/app_database.dart
+++ b/lib/data/database/app_database.dart
@@ -123,6 +123,7 @@ class AppSettingsDao extends DatabaseAccessor<AppDatabase>
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(driftDatabase(name: 'folio'));
+  AppDatabase.forTesting(QueryExecutor e) : super(e);
 
   @override
   int get schemaVersion => 1;

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/providers/settings_providers.dart';
+import '../../core/recurrence/frequency.dart';
+
+const _currencies = [
+  ('GBP', 'British Pound', '£'),
+  ('USD', 'US Dollar', r'$'),
+  ('EUR', 'Euro', '€'),
+  ('CAD', 'Canadian Dollar', r'CA$'),
+  ('AUD', 'Australian Dollar', r'A$'),
+  ('JPY', 'Japanese Yen', '¥'),
+  ('CHF', 'Swiss Franc', 'Fr'),
+  ('INR', 'Indian Rupee', '₹'),
+  ('SGD', 'Singapore Dollar', r'S$'),
+  ('NZD', 'New Zealand Dollar', r'NZ$'),
+];
+
+class OnboardingScreen extends ConsumerStatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  final _controller = PageController();
+  String _currency = 'GBP';
+  Frequency _frequency = Frequency.monthly;
+  int _page = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _next() {
+    _controller.nextPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+    setState(() => _page = 1);
+  }
+
+  Future<void> _done() async {
+    await ref.read(settingsRepositoryProvider).completeOnboarding(
+      currency: _currency,
+      defaultFrequency: _frequency,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _controller,
+                physics: const NeverScrollableScrollPhysics(),
+                children: [_currencyPage(), _frequencyPage()],
+              ),
+            ),
+            _footer(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _currencyPage() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 40, 24, 8),
+          child: Text(
+            'Choose your currency',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 0, 24, 16),
+          child: Text('Used to display all expense amounts.'),
+        ),
+        Expanded(
+          child: ListView(
+            children: _currencies
+                .map((c) => RadioListTile<String>(
+                      title: Text('${c.$2} (${c.$3})'),
+                      subtitle: Text(c.$1),
+                      value: c.$1,
+                      groupValue: _currency,
+                      onChanged: (v) => setState(() => _currency = v!),
+                    ))
+                .toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _frequencyPage() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 40, 24, 8),
+          child: Text(
+            'Default recurrence',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 0, 24, 16),
+          child: Text('Pre-filled when you add a new expense.'),
+        ),
+        Expanded(
+          child: ListView(
+            children: Frequency.values
+                .map((f) => RadioListTile<Frequency>(
+                      title: Text(f.label),
+                      value: f,
+                      groupValue: _frequency,
+                      onChanged: (v) => setState(() => _frequency = v!),
+                    ))
+                .toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _footer() {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [0, 1]
+                .map((i) => Container(
+                      margin: const EdgeInsets.only(right: 6),
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: i == _page
+                            ? Theme.of(context).colorScheme.primary
+                            : Theme.of(context).colorScheme.outlineVariant,
+                      ),
+                    ))
+                .toList(),
+          ),
+          FilledButton(
+            onPressed: _page == 0 ? _next : _done,
+            child: Text(_page == 0 ? 'Next' : 'Done'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/core/settings/settings_repository_test.dart
+++ b/test/core/settings/settings_repository_test.dart
@@ -1,0 +1,56 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:folio/core/recurrence/frequency.dart';
+import 'package:folio/core/settings/settings_repository.dart';
+import 'package:folio/data/database/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late SettingsRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = SettingsRepository(db.appSettingsDao);
+  });
+
+  tearDown(() => db.close());
+
+  test('defaults before load', () {
+    expect(repo.onboardingComplete, isNull);
+    expect(repo.currency, 'GBP');
+    expect(repo.defaultFrequency, Frequency.monthly);
+  });
+
+  test('load with empty DB → onboardingComplete false, defaults kept', () async {
+    await repo.load();
+    expect(repo.onboardingComplete, false);
+    expect(repo.currency, 'GBP');
+    expect(repo.defaultFrequency, Frequency.monthly);
+  });
+
+  test('completeOnboarding saves values and sets flag', () async {
+    await repo.load();
+    await repo.completeOnboarding(currency: 'USD', defaultFrequency: Frequency.weekly);
+    expect(repo.onboardingComplete, true);
+    expect(repo.currency, 'USD');
+    expect(repo.defaultFrequency, Frequency.weekly);
+  });
+
+  test('load after completeOnboarding reads persisted values', () async {
+    await repo.load();
+    await repo.completeOnboarding(currency: 'EUR', defaultFrequency: Frequency.annually);
+    final repo2 = SettingsRepository(db.appSettingsDao);
+    await repo2.load();
+    expect(repo2.onboardingComplete, true);
+    expect(repo2.currency, 'EUR');
+    expect(repo2.defaultFrequency, Frequency.annually);
+  });
+
+  test('completeOnboarding notifies listeners', () async {
+    await repo.load();
+    var notified = false;
+    repo.addListener(() => notified = true);
+    await repo.completeOnboarding(currency: 'GBP', defaultFrequency: Frequency.monthly);
+    expect(notified, true);
+  });
+}


### PR DESCRIPTION
## Summary

- Added `SettingsRepository` (ChangeNotifier) wrapping `AppSettingsDao` with `load()` and `completeOnboarding()` — exposes reactive stream via ChangeNotifier
- Added `settingsRepositoryProvider` (ChangeNotifierProvider) so the repository is accessible in the widget tree
- Converted `router` to `routerProvider` (Riverpod Provider<GoRouter>) with `refreshListenable` and a redirect that gates `/onboarding` based on the `onboarding_complete` flag
- `App` is now a `ConsumerStatefulWidget` that loads settings in `initState` and watches `routerProvider`
- Two-step `OnboardingScreen` (PageView): Step 1 picks currency (GBP pre-selected, 10 options), Step 2 picks default recurrence frequency (Monthly pre-selected, all 8 options)
- Added `FrequencyLabel` extension to `frequency.dart` for human-readable labels
- Added `AppDatabase.forTesting()` constructor for in-memory test database
- 5 unit tests for `SettingsRepository` covering defaults, persistence, and listener notification

## Closes

Closes #5

## Test plan

- [ ] `flutter test` — all 19 tests pass
- [ ] Fresh install (or clear app data): onboarding wizard appears, GBP + Every month pre-selected
- [ ] Select a currency and tap Next → frequency step
- [ ] Select a frequency and tap Done → lands on Calendar tab
- [ ] Restart app → onboarding skipped, Calendar tab shown directly