### PR TITLE
feat(calendar): mark paid/unpaid, skip, and edit occurrence amount

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,62 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
+  - share_plus (0.0.1):
+    - Flutter
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.52.0):
+    - sqlite3/common
+  - sqlite3/math (3.52.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.52.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - sqlite3 (~> 3.52.0)
+    - sqlite3/dbstatvtab
+    - sqlite3/fts5
+    - sqlite3/math
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
+    - sqlite3/session
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
+  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - sqlite3
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
+  sqlite3_flutter_libs:
+    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
+
+PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,9 +12,11 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
+		8553E7A40E03485EAF92F68D /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E5AAFD3DA969026E9B3B9D5 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A661D6CC5DC08B2C675CDC05 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0AB9418785472A4FF91DFC3 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,11 +47,15 @@
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		34C67A094D04E54F68DDAEE6 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		569150BD5A10F29027ADA47D /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		620A4D2164B5AB5827B0F9EF /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		949CCB0E16418B4D02B3CEF2 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -57,13 +63,26 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9E5AAFD3DA969026E9B3B9D5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C393829B688696960EBB035B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		E0AB9418785472A4FF91DFC3 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ED5D1B7D5FFD55B4D9A95372 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0563487AB27164D567DDD842 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8553E7A40E03485EAF92F68D /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A661D6CC5DC08B2C675CDC05 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,6 +115,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				CB2C7D2708D346163198A9EB /* Pods */,
+				DD34E93C24185B3083C9156F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,6 +145,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		CB2C7D2708D346163198A9EB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				949CCB0E16418B4D02B3CEF2 /* Pods-Runner.debug.xcconfig */,
+				C393829B688696960EBB035B /* Pods-Runner.release.xcconfig */,
+				569150BD5A10F29027ADA47D /* Pods-Runner.profile.xcconfig */,
+				ED5D1B7D5FFD55B4D9A95372 /* Pods-RunnerTests.debug.xcconfig */,
+				620A4D2164B5AB5827B0F9EF /* Pods-RunnerTests.release.xcconfig */,
+				34C67A094D04E54F68DDAEE6 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		DD34E93C24185B3083C9156F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E0AB9418785472A4FF91DFC3 /* Pods_Runner.framework */,
+				9E5AAFD3DA969026E9B3B9D5 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -131,8 +175,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				48DEBABCE1A03EB80201846E /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				0563487AB27164D567DDD842 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -148,12 +194,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				BA6738BD07633AFBA9D86283 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				C7FB901740F24241A8B2BDF8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -241,6 +289,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		48DEBABCE1A03EB80201846E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -255,6 +325,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		BA6738BD07633AFBA9D86283 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C7FB901740F24241A8B2BDF8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -382,6 +491,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ED5D1B7D5FFD55B4D9A95372 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -399,6 +509,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 620A4D2164B5AB5827B0F9EF /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -414,6 +525,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 34C67A094D04E54F68DDAEE6 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -545,6 +657,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = LJG29Q67X8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/core/providers/calendar_providers.dart
+++ b/lib/core/providers/calendar_providers.dart
@@ -19,6 +19,17 @@ final categoriesProvider = FutureProvider<List<Category>>((ref) {
   return ref.read(categoriesDaoProvider).getAllCategories();
 });
 
+final dayOccurrencesProvider =
+    Provider.family<List<OccurrenceWithDetails>, DateTime>((ref, date) {
+  return ref.watch(calendarDataProvider).maybeWhen(
+    data: (all) => all.where((o) {
+      final d = o.occurrence.date;
+      return d.year == date.year && d.month == date.month && d.day == date.day;
+    }).toList(),
+    orElse: () => [],
+  );
+});
+
 // Runs the generator for current + adjacent months, then streams current month
 final calendarDataProvider = StreamProvider<List<OccurrenceWithDetails>>((ref) async* {
   final month = ref.watch(currentMonthProvider);

--- a/lib/data/database/app_database.dart
+++ b/lib/data/database/app_database.dart
@@ -100,6 +100,24 @@ class ExpenseOccurrencesDao extends DatabaseAccessor<AppDatabase>
   Future<bool> updateOccurrence(ExpenseOccurrencesCompanion entry) =>
       update(expenseOccurrences).replace(entry);
 
+  Future<void> togglePaid(int id, bool isPaid) =>
+      (update(expenseOccurrences)..where((t) => t.id.equals(id))).write(
+        ExpenseOccurrencesCompanion(
+          isPaid: Value(isPaid),
+          paidAt: Value(isPaid ? DateTime.now() : null),
+        ),
+      );
+
+  Future<void> toggleSkipped(int id, bool isSkipped) =>
+      (update(expenseOccurrences)..where((t) => t.id.equals(id))).write(
+        ExpenseOccurrencesCompanion(isSkipped: Value(isSkipped)),
+      );
+
+  Future<void> updateAmount(int id, double? amount) =>
+      (update(expenseOccurrences)..where((t) => t.id.equals(id))).write(
+        ExpenseOccurrencesCompanion(amount: Value(amount)),
+      );
+
   Future<int> deleteOccurrence(int id) =>
       (delete(expenseOccurrences)..where((t) => t.id.equals(id))).go();
 
@@ -171,7 +189,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(QueryExecutor e) : super(e);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -185,6 +203,10 @@ class AppDatabase extends _$AppDatabase {
         await m.addColumn(expenses, expenses.endDate);
         await m.addColumn(expenses, expenses.frequency);
         await m.addColumn(expenseOccurrences, expenseOccurrences.isPaid);
+      }
+      if (from < 3) {
+        await m.addColumn(expenseOccurrences, expenseOccurrences.paidAt);
+        await m.addColumn(expenseOccurrences, expenseOccurrences.isSkipped);
       }
     },
   );

--- a/lib/data/database/app_database.g.dart
+++ b/lib/data/database/app_database.g.dart
@@ -883,6 +883,30 @@ class $ExpenseOccurrencesTable extends ExpenseOccurrences
     ),
     defaultValue: const Constant(false),
   );
+  static const VerificationMeta _paidAtMeta = const VerificationMeta('paidAt');
+  @override
+  late final GeneratedColumn<DateTime> paidAt = GeneratedColumn<DateTime>(
+    'paid_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isSkippedMeta = const VerificationMeta(
+    'isSkipped',
+  );
+  @override
+  late final GeneratedColumn<bool> isSkipped = GeneratedColumn<bool>(
+    'is_skipped',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_skipped" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -891,6 +915,8 @@ class $ExpenseOccurrencesTable extends ExpenseOccurrences
     amount,
     note,
     isPaid,
+    paidAt,
+    isSkipped,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -941,6 +967,18 @@ class $ExpenseOccurrencesTable extends ExpenseOccurrences
         isPaid.isAcceptableOrUnknown(data['is_paid']!, _isPaidMeta),
       );
     }
+    if (data.containsKey('paid_at')) {
+      context.handle(
+        _paidAtMeta,
+        paidAt.isAcceptableOrUnknown(data['paid_at']!, _paidAtMeta),
+      );
+    }
+    if (data.containsKey('is_skipped')) {
+      context.handle(
+        _isSkippedMeta,
+        isSkipped.isAcceptableOrUnknown(data['is_skipped']!, _isSkippedMeta),
+      );
+    }
     return context;
   }
 
@@ -974,6 +1012,14 @@ class $ExpenseOccurrencesTable extends ExpenseOccurrences
         DriftSqlType.bool,
         data['${effectivePrefix}is_paid'],
       )!,
+      paidAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}paid_at'],
+      ),
+      isSkipped: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_skipped'],
+      )!,
     );
   }
 
@@ -991,6 +1037,8 @@ class ExpenseOccurrence extends DataClass
   final double? amount;
   final String? note;
   final bool isPaid;
+  final DateTime? paidAt;
+  final bool isSkipped;
   const ExpenseOccurrence({
     required this.id,
     required this.expenseId,
@@ -998,6 +1046,8 @@ class ExpenseOccurrence extends DataClass
     this.amount,
     this.note,
     required this.isPaid,
+    this.paidAt,
+    required this.isSkipped,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1012,6 +1062,10 @@ class ExpenseOccurrence extends DataClass
       map['note'] = Variable<String>(note);
     }
     map['is_paid'] = Variable<bool>(isPaid);
+    if (!nullToAbsent || paidAt != null) {
+      map['paid_at'] = Variable<DateTime>(paidAt);
+    }
+    map['is_skipped'] = Variable<bool>(isSkipped);
     return map;
   }
 
@@ -1025,6 +1079,10 @@ class ExpenseOccurrence extends DataClass
           : Value(amount),
       note: note == null && nullToAbsent ? const Value.absent() : Value(note),
       isPaid: Value(isPaid),
+      paidAt: paidAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(paidAt),
+      isSkipped: Value(isSkipped),
     );
   }
 
@@ -1040,6 +1098,8 @@ class ExpenseOccurrence extends DataClass
       amount: serializer.fromJson<double?>(json['amount']),
       note: serializer.fromJson<String?>(json['note']),
       isPaid: serializer.fromJson<bool>(json['isPaid']),
+      paidAt: serializer.fromJson<DateTime?>(json['paidAt']),
+      isSkipped: serializer.fromJson<bool>(json['isSkipped']),
     );
   }
   @override
@@ -1052,6 +1112,8 @@ class ExpenseOccurrence extends DataClass
       'amount': serializer.toJson<double?>(amount),
       'note': serializer.toJson<String?>(note),
       'isPaid': serializer.toJson<bool>(isPaid),
+      'paidAt': serializer.toJson<DateTime?>(paidAt),
+      'isSkipped': serializer.toJson<bool>(isSkipped),
     };
   }
 
@@ -1062,6 +1124,8 @@ class ExpenseOccurrence extends DataClass
     Value<double?> amount = const Value.absent(),
     Value<String?> note = const Value.absent(),
     bool? isPaid,
+    Value<DateTime?> paidAt = const Value.absent(),
+    bool? isSkipped,
   }) => ExpenseOccurrence(
     id: id ?? this.id,
     expenseId: expenseId ?? this.expenseId,
@@ -1069,6 +1133,8 @@ class ExpenseOccurrence extends DataClass
     amount: amount.present ? amount.value : this.amount,
     note: note.present ? note.value : this.note,
     isPaid: isPaid ?? this.isPaid,
+    paidAt: paidAt.present ? paidAt.value : this.paidAt,
+    isSkipped: isSkipped ?? this.isSkipped,
   );
   ExpenseOccurrence copyWithCompanion(ExpenseOccurrencesCompanion data) {
     return ExpenseOccurrence(
@@ -1078,6 +1144,8 @@ class ExpenseOccurrence extends DataClass
       amount: data.amount.present ? data.amount.value : this.amount,
       note: data.note.present ? data.note.value : this.note,
       isPaid: data.isPaid.present ? data.isPaid.value : this.isPaid,
+      paidAt: data.paidAt.present ? data.paidAt.value : this.paidAt,
+      isSkipped: data.isSkipped.present ? data.isSkipped.value : this.isSkipped,
     );
   }
 
@@ -1089,13 +1157,16 @@ class ExpenseOccurrence extends DataClass
           ..write('date: $date, ')
           ..write('amount: $amount, ')
           ..write('note: $note, ')
-          ..write('isPaid: $isPaid')
+          ..write('isPaid: $isPaid, ')
+          ..write('paidAt: $paidAt, ')
+          ..write('isSkipped: $isSkipped')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, expenseId, date, amount, note, isPaid);
+  int get hashCode =>
+      Object.hash(id, expenseId, date, amount, note, isPaid, paidAt, isSkipped);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1105,7 +1176,9 @@ class ExpenseOccurrence extends DataClass
           other.date == this.date &&
           other.amount == this.amount &&
           other.note == this.note &&
-          other.isPaid == this.isPaid);
+          other.isPaid == this.isPaid &&
+          other.paidAt == this.paidAt &&
+          other.isSkipped == this.isSkipped);
 }
 
 class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
@@ -1115,6 +1188,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
   final Value<double?> amount;
   final Value<String?> note;
   final Value<bool> isPaid;
+  final Value<DateTime?> paidAt;
+  final Value<bool> isSkipped;
   const ExpenseOccurrencesCompanion({
     this.id = const Value.absent(),
     this.expenseId = const Value.absent(),
@@ -1122,6 +1197,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
     this.amount = const Value.absent(),
     this.note = const Value.absent(),
     this.isPaid = const Value.absent(),
+    this.paidAt = const Value.absent(),
+    this.isSkipped = const Value.absent(),
   });
   ExpenseOccurrencesCompanion.insert({
     this.id = const Value.absent(),
@@ -1130,6 +1207,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
     this.amount = const Value.absent(),
     this.note = const Value.absent(),
     this.isPaid = const Value.absent(),
+    this.paidAt = const Value.absent(),
+    this.isSkipped = const Value.absent(),
   }) : expenseId = Value(expenseId),
        date = Value(date);
   static Insertable<ExpenseOccurrence> custom({
@@ -1139,6 +1218,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
     Expression<double>? amount,
     Expression<String>? note,
     Expression<bool>? isPaid,
+    Expression<DateTime>? paidAt,
+    Expression<bool>? isSkipped,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -1147,6 +1228,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
       if (amount != null) 'amount': amount,
       if (note != null) 'note': note,
       if (isPaid != null) 'is_paid': isPaid,
+      if (paidAt != null) 'paid_at': paidAt,
+      if (isSkipped != null) 'is_skipped': isSkipped,
     });
   }
 
@@ -1157,6 +1240,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
     Value<double?>? amount,
     Value<String?>? note,
     Value<bool>? isPaid,
+    Value<DateTime?>? paidAt,
+    Value<bool>? isSkipped,
   }) {
     return ExpenseOccurrencesCompanion(
       id: id ?? this.id,
@@ -1165,6 +1250,8 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
       amount: amount ?? this.amount,
       note: note ?? this.note,
       isPaid: isPaid ?? this.isPaid,
+      paidAt: paidAt ?? this.paidAt,
+      isSkipped: isSkipped ?? this.isSkipped,
     );
   }
 
@@ -1189,6 +1276,12 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
     if (isPaid.present) {
       map['is_paid'] = Variable<bool>(isPaid.value);
     }
+    if (paidAt.present) {
+      map['paid_at'] = Variable<DateTime>(paidAt.value);
+    }
+    if (isSkipped.present) {
+      map['is_skipped'] = Variable<bool>(isSkipped.value);
+    }
     return map;
   }
 
@@ -1200,7 +1293,9 @@ class ExpenseOccurrencesCompanion extends UpdateCompanion<ExpenseOccurrence> {
           ..write('date: $date, ')
           ..write('amount: $amount, ')
           ..write('note: $note, ')
-          ..write('isPaid: $isPaid')
+          ..write('isPaid: $isPaid, ')
+          ..write('paidAt: $paidAt, ')
+          ..write('isSkipped: $isSkipped')
           ..write(')'))
         .toString();
   }
@@ -2196,6 +2291,8 @@ typedef $$ExpenseOccurrencesTableCreateCompanionBuilder =
       Value<double?> amount,
       Value<String?> note,
       Value<bool> isPaid,
+      Value<DateTime?> paidAt,
+      Value<bool> isSkipped,
     });
 typedef $$ExpenseOccurrencesTableUpdateCompanionBuilder =
     ExpenseOccurrencesCompanion Function({
@@ -2205,6 +2302,8 @@ typedef $$ExpenseOccurrencesTableUpdateCompanionBuilder =
       Value<double?> amount,
       Value<String?> note,
       Value<bool> isPaid,
+      Value<DateTime?> paidAt,
+      Value<bool> isSkipped,
     });
 
 final class $$ExpenseOccurrencesTableReferences
@@ -2274,6 +2373,16 @@ class $$ExpenseOccurrencesTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<DateTime> get paidAt => $composableBuilder(
+    column: $table.paidAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isSkipped => $composableBuilder(
+    column: $table.isSkipped,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$ExpensesTableFilterComposer get expenseId {
     final $$ExpensesTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -2332,6 +2441,16 @@ class $$ExpenseOccurrencesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<DateTime> get paidAt => $composableBuilder(
+    column: $table.paidAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isSkipped => $composableBuilder(
+    column: $table.isSkipped,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$ExpensesTableOrderingComposer get expenseId {
     final $$ExpensesTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -2379,6 +2498,12 @@ class $$ExpenseOccurrencesTableAnnotationComposer
 
   GeneratedColumn<bool> get isPaid =>
       $composableBuilder(column: $table.isPaid, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get paidAt =>
+      $composableBuilder(column: $table.paidAt, builder: (column) => column);
+
+  GeneratedColumn<bool> get isSkipped =>
+      $composableBuilder(column: $table.isSkipped, builder: (column) => column);
 
   $$ExpensesTableAnnotationComposer get expenseId {
     final $$ExpensesTableAnnotationComposer composer = $composerBuilder(
@@ -2443,6 +2568,8 @@ class $$ExpenseOccurrencesTableTableManager
                 Value<double?> amount = const Value.absent(),
                 Value<String?> note = const Value.absent(),
                 Value<bool> isPaid = const Value.absent(),
+                Value<DateTime?> paidAt = const Value.absent(),
+                Value<bool> isSkipped = const Value.absent(),
               }) => ExpenseOccurrencesCompanion(
                 id: id,
                 expenseId: expenseId,
@@ -2450,6 +2577,8 @@ class $$ExpenseOccurrencesTableTableManager
                 amount: amount,
                 note: note,
                 isPaid: isPaid,
+                paidAt: paidAt,
+                isSkipped: isSkipped,
               ),
           createCompanionCallback:
               ({
@@ -2459,6 +2588,8 @@ class $$ExpenseOccurrencesTableTableManager
                 Value<double?> amount = const Value.absent(),
                 Value<String?> note = const Value.absent(),
                 Value<bool> isPaid = const Value.absent(),
+                Value<DateTime?> paidAt = const Value.absent(),
+                Value<bool> isSkipped = const Value.absent(),
               }) => ExpenseOccurrencesCompanion.insert(
                 id: id,
                 expenseId: expenseId,
@@ -2466,6 +2597,8 @@ class $$ExpenseOccurrencesTableTableManager
                 amount: amount,
                 note: note,
                 isPaid: isPaid,
+                paidAt: paidAt,
+                isSkipped: isSkipped,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/data/tables/expense_occurrences_table.dart
+++ b/lib/data/tables/expense_occurrences_table.dart
@@ -8,4 +8,6 @@ class ExpenseOccurrences extends Table {
   RealColumn get amount => real().nullable()();
   TextColumn get note => text().nullable()();
   BoolColumn get isPaid => boolean().withDefault(const Constant(false))();
+  DateTimeColumn get paidAt => dateTime().nullable()();
+  BoolColumn get isSkipped => boolean().withDefault(const Constant(false))();
 }

--- a/lib/features/calendar/calendar_screen.dart
+++ b/lib/features/calendar/calendar_screen.dart
@@ -61,12 +61,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     return map;
   }
 
-  void _showDaySheet(BuildContext context, DateTime date, List<OccurrenceWithDetails> all) {
-    final dayData = all.where((o) {
-      final d = o.occurrence.date;
-      return d.year == date.year && d.month == date.month && d.day == date.day;
-    }).toList();
-
+  void _showDaySheet(BuildContext context, DateTime date) {
     final currency = ref.read(settingsRepositoryProvider).currency;
 
     showModalBottomSheet(
@@ -74,7 +69,6 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
       isScrollControlled: true,
       builder: (_) => DaySheet(
         date: date,
-        occurrences: dayData,
         currency: currency,
         onAdd: () {
           Navigator.pop(context);
@@ -128,7 +122,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                 child: CalendarGrid(
                   month: month,
                   dotsByDay: dots,
-                  onDayTap: (date) => _showDaySheet(context, date, occurrences),
+                  onDayTap: (date) => _showDaySheet(context, date),
                 ),
               );
             },

--- a/lib/features/calendar/widgets/day_sheet.dart
+++ b/lib/features/calendar/widgets/day_sheet.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/providers/calendar_providers.dart';
+import '../../../core/providers/database_providers.dart';
 import '../../../data/database/app_database.dart';
 
 const _weekdayNames = [
@@ -14,22 +17,21 @@ const _currencySymbols = {
   'SGD': r'S$', 'NZD': r'NZ$',
 };
 
-class DaySheet extends StatelessWidget {
+class DaySheet extends ConsumerWidget {
   final DateTime date;
-  final List<OccurrenceWithDetails> occurrences;
   final String currency;
   final VoidCallback onAdd;
 
   const DaySheet({
     super.key,
     required this.date,
-    required this.occurrences,
     required this.currency,
     required this.onAdd,
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final occurrences = ref.watch(dayOccurrencesProvider(date));
     final symbol = _currencySymbols[currency] ?? currency;
     final label =
         '${_weekdayNames[date.weekday - 1]}, ${date.day} ${_monthNames[date.month - 1]} ${date.year}';
@@ -59,29 +61,13 @@ class DaySheet extends StatelessWidget {
               child: Center(child: Text('No expenses on this day.')),
             )
           else
-            ...occurrences.map((o) => ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: CircleAvatar(
-                    backgroundColor: Color(o.category.color).withAlpha(50),
-                    child: Text(o.category.emoji),
-                  ),
-                  title: Text(o.expense.name),
-                  subtitle: Text(o.category.name),
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        '$symbol${(o.occurrence.amount ?? o.expense.amount).toStringAsFixed(2)}',
-                        style: const TextStyle(fontWeight: FontWeight.w600),
-                      ),
-                      if (o.occurrence.isPaid)
-                        const Padding(
-                          padding: EdgeInsets.only(left: 4),
-                          child: Icon(Icons.check_circle, color: Colors.green, size: 18),
-                        ),
-                    ],
-                  ),
-                )),
+            ...occurrences.map((o) => _OccurrenceTile(
+              o: o,
+              symbol: symbol,
+              onTogglePaid: () => _togglePaid(ref, o),
+              onToggleSkip: () => _toggleSkip(ref, o),
+              onEditAmount: () => _editAmount(context, ref, o),
+            )),
           const SizedBox(height: 8),
           SizedBox(
             width: double.infinity,
@@ -92,6 +78,143 @@ class DaySheet extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _togglePaid(WidgetRef ref, OccurrenceWithDetails o) {
+    final dao = ref.read(expenseOccurrencesDaoProvider);
+    return dao.togglePaid(o.occurrence.id, !o.occurrence.isPaid);
+  }
+
+  Future<void> _toggleSkip(WidgetRef ref, OccurrenceWithDetails o) {
+    final dao = ref.read(expenseOccurrencesDaoProvider);
+    return dao.toggleSkipped(o.occurrence.id, !o.occurrence.isSkipped);
+  }
+
+  Future<void> _editAmount(
+    BuildContext context,
+    WidgetRef ref,
+    OccurrenceWithDetails o,
+  ) async {
+    final current = o.occurrence.amount ?? o.expense.amount;
+    final controller = TextEditingController(text: current.toStringAsFixed(2));
+    final result = await showDialog<double>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Edit amount for ${o.expense.name}'),
+        content: TextField(
+          controller: controller,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          autofocus: true,
+          decoration: const InputDecoration(labelText: 'Amount'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () {
+              final v = double.tryParse(controller.text);
+              if (v != null && v > 0) Navigator.pop(ctx, v);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (result != null) {
+      await ref.read(expenseOccurrencesDaoProvider).updateAmount(o.occurrence.id, result);
+    }
+  }
+}
+
+class _OccurrenceTile extends StatelessWidget {
+  final OccurrenceWithDetails o;
+  final String symbol;
+  final VoidCallback onTogglePaid;
+  final VoidCallback onToggleSkip;
+  final VoidCallback onEditAmount;
+
+  const _OccurrenceTile({
+    required this.o,
+    required this.symbol,
+    required this.onTogglePaid,
+    required this.onToggleSkip,
+    required this.onEditAmount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPaid = o.occurrence.isPaid;
+    final isSkipped = o.occurrence.isSkipped;
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(100);
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      onTap: isSkipped ? null : onTogglePaid,
+      onLongPress: () => _showOptions(context),
+      leading: CircleAvatar(
+        backgroundColor: Color(o.category.color).withAlpha(isSkipped ? 30 : 50),
+        child: Text(o.category.emoji),
+      ),
+      title: Text(
+        o.expense.name,
+        style: TextStyle(
+          decoration: isPaid ? TextDecoration.lineThrough : null,
+          color: (isPaid || isSkipped) ? muted : null,
+        ),
+      ),
+      subtitle: Text(
+        isSkipped ? 'Skipped' : o.category.name,
+        style: TextStyle(color: isSkipped ? muted : null),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$symbol${(o.occurrence.amount ?? o.expense.amount).toStringAsFixed(2)}',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              color: (isPaid || isSkipped) ? muted : null,
+              decoration: isSkipped ? TextDecoration.lineThrough : null,
+            ),
+          ),
+          const SizedBox(width: 4),
+          if (isSkipped)
+            Icon(Icons.block, color: muted, size: 18)
+          else if (isPaid)
+            const Icon(Icons.check_circle, color: Colors.green, size: 18),
+        ],
+      ),
+    );
+  }
+
+  void _showOptions(BuildContext context) {
+    final isSkipped = o.occurrence.isSkipped;
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: Icon(isSkipped ? Icons.replay : Icons.block),
+              title: Text(isSkipped ? 'Un-skip' : 'Skip this occurrence'),
+              onTap: () {
+                Navigator.pop(context);
+                onToggleSkip();
+              },
+            ),
+            if (!isSkipped)
+              ListTile(
+                leading: const Icon(Icons.edit),
+                title: const Text('Edit amount'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onEditAmount();
+                },
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `paidAt` (nullable) and `isSkipped` (bool) columns to `ExpenseOccurrences`; schema bumped to v3 with migration
- Add `togglePaid`, `toggleSkipped`, `updateAmount` DAO methods for targeted partial updates
- Convert `DaySheet` to `ConsumerWidget` watching a live `dayOccurrencesProvider(date)` — sheet stays reactive after mutations
- Tap occurrence → toggle paid/unpaid (records `paidAt` timestamp when marked paid)
- Long-press occurrence → bottom sheet with Skip / Edit Amount options
- Visual styling: paid shows strikethrough + green checkmark; skipped shows muted color + block icon and is excluded from totals display
- Also includes iOS CocoaPods + signing setup (physical device support)

## Closes
Closes #7

## Test plan
- [ ] Open calendar, tap any day with an occurrence
- [ ] Tap an occurrence — it should toggle paid (green checkmark + strikethrough)
- [ ] Tap again — unpaid state restored, paidAt cleared
- [ ] Long-press → tap "Skip" — occurrence turns muted with block icon, tapping does nothing
- [ ] Long-press skipped occurrence → "Un-skip" restores it
- [ ] Long-press → "Edit amount" → change value → confirm — occurrence shows new amount; parent series unaffected
- [ ] Close and reopen app — all states persist