### PR TITLE
feat(settings): category management — add, edit, delete custom categories

### DIFF
--- a/lib/core/providers/calendar_providers.dart
+++ b/lib/core/providers/calendar_providers.dart
@@ -15,8 +15,8 @@ final occurrenceGeneratorProvider = Provider<OccurrenceGeneratorService>((ref) {
   );
 });
 
-final categoriesProvider = FutureProvider<List<Category>>((ref) {
-  return ref.read(categoriesDaoProvider).getAllCategories();
+final categoriesProvider = StreamProvider<List<Category>>((ref) {
+  return ref.watch(categoriesDaoProvider).watchAllCategories();
 });
 
 final dayOccurrencesProvider =

--- a/lib/data/database/app_database.dart
+++ b/lib/data/database/app_database.dart
@@ -126,6 +126,11 @@ class ExpenseOccurrencesDao extends DatabaseAccessor<AppDatabase>
   Future<int> deleteOccurrence(int id) =>
       (delete(expenseOccurrences)..where((t) => t.id.equals(id))).go();
 
+  Future<int> deleteOccurrencesByExpense(int expenseId) =>
+      (delete(expenseOccurrences)
+            ..where((t) => t.expenseId.equals(expenseId)))
+          .go();
+
   Future<int> deleteFutureUnpaidOccurrences(int expenseId, DateTime afterDate) =>
       (delete(expenseOccurrences)
             ..where((t) =>
@@ -203,7 +208,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(QueryExecutor e) : super(e);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -221,6 +226,9 @@ class AppDatabase extends _$AppDatabase {
       if (from < 3) {
         await m.addColumn(expenseOccurrences, expenseOccurrences.paidAt);
         await m.addColumn(expenseOccurrences, expenseOccurrences.isSkipped);
+      }
+      if (from < 4) {
+        await m.addColumn(categories, categories.isCustom);
       }
     },
   );

--- a/lib/data/database/app_database.g.dart
+++ b/lib/data/database/app_database.g.dart
@@ -66,8 +66,23 @@ class $CategoriesTable extends Categories
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _isCustomMeta = const VerificationMeta(
+    'isCustom',
+  );
   @override
-  List<GeneratedColumn> get $columns => [id, name, emoji, color];
+  late final GeneratedColumn<bool> isCustom = GeneratedColumn<bool>(
+    'is_custom',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_custom" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, name, emoji, color, isCustom];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -107,6 +122,12 @@ class $CategoriesTable extends Categories
     } else if (isInserting) {
       context.missing(_colorMeta);
     }
+    if (data.containsKey('is_custom')) {
+      context.handle(
+        _isCustomMeta,
+        isCustom.isAcceptableOrUnknown(data['is_custom']!, _isCustomMeta),
+      );
+    }
     return context;
   }
 
@@ -132,6 +153,10 @@ class $CategoriesTable extends Categories
         DriftSqlType.int,
         data['${effectivePrefix}color'],
       )!,
+      isCustom: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_custom'],
+      )!,
     );
   }
 
@@ -146,11 +171,13 @@ class Category extends DataClass implements Insertable<Category> {
   final String name;
   final String emoji;
   final int color;
+  final bool isCustom;
   const Category({
     required this.id,
     required this.name,
     required this.emoji,
     required this.color,
+    required this.isCustom,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -159,6 +186,7 @@ class Category extends DataClass implements Insertable<Category> {
     map['name'] = Variable<String>(name);
     map['emoji'] = Variable<String>(emoji);
     map['color'] = Variable<int>(color);
+    map['is_custom'] = Variable<bool>(isCustom);
     return map;
   }
 
@@ -168,6 +196,7 @@ class Category extends DataClass implements Insertable<Category> {
       name: Value(name),
       emoji: Value(emoji),
       color: Value(color),
+      isCustom: Value(isCustom),
     );
   }
 
@@ -181,6 +210,7 @@ class Category extends DataClass implements Insertable<Category> {
       name: serializer.fromJson<String>(json['name']),
       emoji: serializer.fromJson<String>(json['emoji']),
       color: serializer.fromJson<int>(json['color']),
+      isCustom: serializer.fromJson<bool>(json['isCustom']),
     );
   }
   @override
@@ -191,22 +221,30 @@ class Category extends DataClass implements Insertable<Category> {
       'name': serializer.toJson<String>(name),
       'emoji': serializer.toJson<String>(emoji),
       'color': serializer.toJson<int>(color),
+      'isCustom': serializer.toJson<bool>(isCustom),
     };
   }
 
-  Category copyWith({int? id, String? name, String? emoji, int? color}) =>
-      Category(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        emoji: emoji ?? this.emoji,
-        color: color ?? this.color,
-      );
+  Category copyWith({
+    int? id,
+    String? name,
+    String? emoji,
+    int? color,
+    bool? isCustom,
+  }) => Category(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    emoji: emoji ?? this.emoji,
+    color: color ?? this.color,
+    isCustom: isCustom ?? this.isCustom,
+  );
   Category copyWithCompanion(CategoriesCompanion data) {
     return Category(
       id: data.id.present ? data.id.value : this.id,
       name: data.name.present ? data.name.value : this.name,
       emoji: data.emoji.present ? data.emoji.value : this.emoji,
       color: data.color.present ? data.color.value : this.color,
+      isCustom: data.isCustom.present ? data.isCustom.value : this.isCustom,
     );
   }
 
@@ -216,13 +254,14 @@ class Category extends DataClass implements Insertable<Category> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('emoji: $emoji, ')
-          ..write('color: $color')
+          ..write('color: $color, ')
+          ..write('isCustom: $isCustom')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, name, emoji, color);
+  int get hashCode => Object.hash(id, name, emoji, color, isCustom);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -230,7 +269,8 @@ class Category extends DataClass implements Insertable<Category> {
           other.id == this.id &&
           other.name == this.name &&
           other.emoji == this.emoji &&
-          other.color == this.color);
+          other.color == this.color &&
+          other.isCustom == this.isCustom);
 }
 
 class CategoriesCompanion extends UpdateCompanion<Category> {
@@ -238,17 +278,20 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
   final Value<String> name;
   final Value<String> emoji;
   final Value<int> color;
+  final Value<bool> isCustom;
   const CategoriesCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
     this.emoji = const Value.absent(),
     this.color = const Value.absent(),
+    this.isCustom = const Value.absent(),
   });
   CategoriesCompanion.insert({
     this.id = const Value.absent(),
     required String name,
     required String emoji,
     required int color,
+    this.isCustom = const Value.absent(),
   }) : name = Value(name),
        emoji = Value(emoji),
        color = Value(color);
@@ -257,12 +300,14 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     Expression<String>? name,
     Expression<String>? emoji,
     Expression<int>? color,
+    Expression<bool>? isCustom,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       if (emoji != null) 'emoji': emoji,
       if (color != null) 'color': color,
+      if (isCustom != null) 'is_custom': isCustom,
     });
   }
 
@@ -271,12 +316,14 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     Value<String>? name,
     Value<String>? emoji,
     Value<int>? color,
+    Value<bool>? isCustom,
   }) {
     return CategoriesCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
       emoji: emoji ?? this.emoji,
       color: color ?? this.color,
+      isCustom: isCustom ?? this.isCustom,
     );
   }
 
@@ -295,6 +342,9 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     if (color.present) {
       map['color'] = Variable<int>(color.value);
     }
+    if (isCustom.present) {
+      map['is_custom'] = Variable<bool>(isCustom.value);
+    }
     return map;
   }
 
@@ -304,7 +354,8 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('emoji: $emoji, ')
-          ..write('color: $color')
+          ..write('color: $color, ')
+          ..write('isCustom: $isCustom')
           ..write(')'))
         .toString();
   }
@@ -1542,6 +1593,7 @@ typedef $$CategoriesTableCreateCompanionBuilder =
       required String name,
       required String emoji,
       required int color,
+      Value<bool> isCustom,
     });
 typedef $$CategoriesTableUpdateCompanionBuilder =
     CategoriesCompanion Function({
@@ -1549,6 +1601,7 @@ typedef $$CategoriesTableUpdateCompanionBuilder =
       Value<String> name,
       Value<String> emoji,
       Value<int> color,
+      Value<bool> isCustom,
     });
 
 final class $$CategoriesTableReferences
@@ -1601,6 +1654,11 @@ class $$CategoriesTableFilterComposer
 
   ColumnFilters<int> get color => $composableBuilder(
     column: $table.color,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isCustom => $composableBuilder(
+    column: $table.isCustom,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -1658,6 +1716,11 @@ class $$CategoriesTableOrderingComposer
     column: $table.color,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<bool> get isCustom => $composableBuilder(
+    column: $table.isCustom,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$CategoriesTableAnnotationComposer
@@ -1680,6 +1743,9 @@ class $$CategoriesTableAnnotationComposer
 
   GeneratedColumn<int> get color =>
       $composableBuilder(column: $table.color, builder: (column) => column);
+
+  GeneratedColumn<bool> get isCustom =>
+      $composableBuilder(column: $table.isCustom, builder: (column) => column);
 
   Expression<T> expensesRefs<T extends Object>(
     Expression<T> Function($$ExpensesTableAnnotationComposer a) f,
@@ -1739,11 +1805,13 @@ class $$CategoriesTableTableManager
                 Value<String> name = const Value.absent(),
                 Value<String> emoji = const Value.absent(),
                 Value<int> color = const Value.absent(),
+                Value<bool> isCustom = const Value.absent(),
               }) => CategoriesCompanion(
                 id: id,
                 name: name,
                 emoji: emoji,
                 color: color,
+                isCustom: isCustom,
               ),
           createCompanionCallback:
               ({
@@ -1751,11 +1819,13 @@ class $$CategoriesTableTableManager
                 required String name,
                 required String emoji,
                 required int color,
+                Value<bool> isCustom = const Value.absent(),
               }) => CategoriesCompanion.insert(
                 id: id,
                 name: name,
                 emoji: emoji,
                 color: color,
+                isCustom: isCustom,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/data/tables/categories_table.dart
+++ b/lib/data/tables/categories_table.dart
@@ -5,4 +5,5 @@ class Categories extends Table {
   TextColumn get name => text()();
   TextColumn get emoji => text()();
   IntColumn get color => integer()();
+  BoolColumn get isCustom => boolean().withDefault(const Constant(false))();
 }

--- a/lib/features/settings/categories_screen.dart
+++ b/lib/features/settings/categories_screen.dart
@@ -1,0 +1,296 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/providers/calendar_providers.dart';
+import '../../core/providers/database_providers.dart';
+import '../../data/database/app_database.dart';
+
+const _kEmojis = [
+  '🏠','🚗','🛒','🎬','💊','📱','🍽','📚','👕','💼','💰','🔧',
+  '✈️','🏃','🐶','🎮','🎵','💅','🍺','☕','🏋','🎁','🏥','📦',
+  '💻','📷','🌿','🏖','🎓','🚀','🔑','💡','🌍','🎯','🛠','🎪',
+];
+
+const _kColors = [
+  0xFF5C6BC0, 0xFF42A5F5, 0xFF66BB6A, 0xFFAB47BC,
+  0xFFEF5350, 0xFF26C6DA, 0xFFFF7043, 0xFF29B6F6,
+  0xFFEC407A, 0xFF78909C, 0xFFFFCA28, 0xFF8D6E63,
+  0xFF26A69A, 0xFF9CCC65, 0xFFFFA726, 0xFF7E57C2,
+];
+
+class CategoriesScreen extends ConsumerWidget {
+  const CategoriesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesAsync = ref.watch(categoriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Categories')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showForm(context, ref, null),
+        child: const Icon(Icons.add),
+      ),
+      body: categoriesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (cats) => ListView.builder(
+          itemCount: cats.length,
+          itemBuilder: (context, i) {
+            final cat = cats[i];
+            return ListTile(
+              leading: CircleAvatar(
+                backgroundColor: Color(cat.color).withAlpha(50),
+                child: Text(cat.emoji),
+              ),
+              title: Text(cat.name),
+              subtitle: Text(cat.isCustom ? 'Custom' : 'Predefined'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.edit, size: 20),
+                    onPressed: () => _showForm(context, ref, cat),
+                  ),
+                  if (cat.isCustom)
+                    IconButton(
+                      icon: const Icon(Icons.delete, size: 20),
+                      onPressed: () => _confirmDelete(context, ref, cat),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showForm(BuildContext context, WidgetRef ref, Category? existing) async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => _CategoryForm(existing: existing),
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref, Category cat) async {
+    final expensesDao = ref.read(expensesDaoProvider);
+    final occurrencesDao = ref.read(expenseOccurrencesDaoProvider);
+    final categoriesDao = ref.read(categoriesDaoProvider);
+
+    final expenses = await expensesDao.getExpensesByCategory(cat.id);
+
+    if (!context.mounted) return;
+
+    if (expenses.isEmpty) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Delete category?'),
+          content: Text('Delete "${cat.name}"?'),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+            FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Delete')),
+          ],
+        ),
+      );
+      if (confirmed == true) await categoriesDao.deleteCategory(cat.id);
+    } else {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Delete category?'),
+          content: Text(
+            '"${cat.name}" is used by ${expenses.length} expense(s). '
+            'Deleting it will also delete those expenses and all their payment history.',
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Delete all'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed == true) {
+        for (final e in expenses) {
+          await occurrencesDao.deleteOccurrencesByExpense(e.id);
+          await expensesDao.deleteExpense(e.id);
+        }
+        await categoriesDao.deleteCategory(cat.id);
+      }
+    }
+  }
+}
+
+class _CategoryForm extends ConsumerStatefulWidget {
+  final Category? existing;
+  const _CategoryForm({this.existing});
+
+  @override
+  ConsumerState<_CategoryForm> createState() => _CategoryFormState();
+}
+
+class _CategoryFormState extends ConsumerState<_CategoryForm> {
+  late final TextEditingController _nameCtrl;
+  late String _emoji;
+  late int _color;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameCtrl = TextEditingController(text: widget.existing?.name ?? '');
+    _emoji = widget.existing?.emoji ?? _kEmojis.first;
+    _color = widget.existing?.color ?? _kColors.first;
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEdit = widget.existing != null;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16, right: 16, top: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  isEdit ? 'Edit category' : 'New category',
+                  style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _nameCtrl,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text('Icon', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 120,
+            child: GridView.builder(
+              scrollDirection: Axis.horizontal,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                mainAxisSpacing: 4,
+                crossAxisSpacing: 4,
+              ),
+              itemCount: _kEmojis.length,
+              itemBuilder: (context, i) {
+                final e = _kEmojis[i];
+                final selected = e == _emoji;
+                return GestureDetector(
+                  onTap: () => setState(() => _emoji = e),
+                  child: Container(
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: selected
+                          ? Theme.of(context).colorScheme.primaryContainer
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                      border: selected
+                          ? Border.all(
+                              color: Theme.of(context).colorScheme.primary,
+                              width: 2,
+                            )
+                          : null,
+                    ),
+                    child: Text(e, style: const TextStyle(fontSize: 22)),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text('Color', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _kColors.map((c) {
+              final selected = c == _color;
+              return GestureDetector(
+                onTap: () => setState(() => _color = c),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: Color(c),
+                    shape: BoxShape.circle,
+                    border: selected
+                        ? Border.all(
+                            color: Theme.of(context).colorScheme.onSurface,
+                            width: 3,
+                          )
+                        : null,
+                  ),
+                  child: selected
+                      ? const Icon(Icons.check, color: Colors.white, size: 18)
+                      : null,
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _save,
+              child: Text(isEdit ? 'Save' : 'Add category'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final name = _nameCtrl.text.trim();
+    if (name.isEmpty) return;
+
+    final dao = ref.read(categoriesDaoProvider);
+
+    if (widget.existing != null) {
+      await dao.updateCategory(CategoriesCompanion(
+        id: Value(widget.existing!.id),
+        name: Value(name),
+        emoji: Value(_emoji),
+        color: Value(_color),
+        isCustom: Value(widget.existing!.isCustom),
+      ));
+    } else {
+      await dao.insertCategory(CategoriesCompanion.insert(
+        name: name,
+        emoji: _emoji,
+        color: _color,
+        isCustom: const Value(true),
+      ));
+    }
+
+    if (mounted) Navigator.pop(context);
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,12 +1,27 @@
 import 'package:flutter/material.dart';
+import 'categories_screen.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Settings')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.category),
+            title: const Text('Categories'),
+            subtitle: const Text('Add, edit, or remove categories'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const CategoriesScreen()),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add `isCustom` boolean column to `Categories` table (default `false`); schema bumped to v4 with migration — existing seeded categories get `isCustom = false` automatically
- Add `deleteOccurrencesByExpense(expenseId)` bulk delete helper to `ExpenseOccurrencesDao`
- Upgrade `categoriesProvider` from `FutureProvider` (one-shot) to `StreamProvider` using `watchAllCategories()` — category picker in AddExpenseForm now live-updates when categories change
- Replace Settings screen stub with a real screen linking to Categories
- **Categories screen**: lists all categories with emoji, name, "Predefined"/"Custom" label; FAB to add; edit button on all; delete button only on custom categories
- **Add/edit form** (bottom sheet): name field, scrollable emoji picker (36 curated emojis), color swatch picker (16 distinct colors)
- **Delete with expenses**: if a custom category has associated expenses, prompts user that deleting will also remove those expenses and their occurrence history; cascades on confirm

## Closes
Closes #10

## Test plan
- [ ] Settings tab → Categories → see all 12 predefined categories, no delete button on them
- [ ] Tap edit on any predefined category → change name/emoji/color → save → updates everywhere including calendar
- [ ] FAB → add new category → appears in list with "Custom" label and in expense category picker
- [ ] Delete a custom category with no expenses → simple confirm → gone
- [ ] Delete a custom category that has expenses → warning dialog mentions count → confirm → category + expenses + occurrences all removed
- [ ] Custom categories appear immediately in AddExpenseForm dropdown (no app restart needed)