### PR TITLE
fix(calendar): keep PageView mounted across month changes (#24)

### DIFF
--- a/lib/features/calendar/calendar_screen.dart
+++ b/lib/features/calendar/calendar_screen.dart
@@ -90,6 +90,9 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   Widget build(BuildContext context) {
     final currentMonth = ref.watch(currentMonthProvider);
     final calendarAsync = ref.watch(calendarDataProvider);
+    // Keep PageView always mounted so PageController stays attached.
+    // valueOrNull is null while loading → empty dots until data arrives.
+    final dots = _buildDots(calendarAsync.valueOrNull ?? []);
 
     return Scaffold(
       appBar: AppBar(
@@ -105,32 +108,28 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           ),
         ],
       ),
-      body: calendarAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
-        data: (occurrences) {
-          final dots = _buildDots(occurrences);
-          return PageView.builder(
-            controller: _pageController,
-            onPageChanged: (page) {
-              ref.read(currentMonthProvider.notifier).state = _pageToMonth(page);
-            },
-            itemBuilder: (context, page) {
-              final month = _pageToMonth(page);
-              final startSunday = ref.read(settingsRepositoryProvider).weekStartSunday;
-              return SingleChildScrollView(
-                padding: const EdgeInsets.all(8),
-                child: CalendarGrid(
-                  month: month,
-                  dotsByDay: dots,
-                  onDayTap: (date) => _showDaySheet(context, date),
-                  startOnSunday: startSunday,
-                ),
-              );
-            },
-          );
-        },
-      ),
+      body: calendarAsync.hasError
+          ? Center(child: Text('Error: ${calendarAsync.error}'))
+          : PageView.builder(
+              controller: _pageController,
+              onPageChanged: (page) {
+                ref.read(currentMonthProvider.notifier).state = _pageToMonth(page);
+              },
+              itemBuilder: (context, page) {
+                final month = _pageToMonth(page);
+                final startSunday =
+                    ref.read(settingsRepositoryProvider).weekStartSunday;
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(8),
+                  child: CalendarGrid(
+                    month: month,
+                    dotsByDay: dots,
+                    onDayTap: (date) => _showDaySheet(context, date),
+                    startOnSunday: startSunday,
+                  ),
+                );
+              },
+            ),
     );
   }
 }


### PR DESCRIPTION
## Summary

- PageView is now always mounted in the widget tree; the `loading` branch no longer replaces it with a `CircularProgressIndicator`
- Dots are computed from `calendarAsync.valueOrNull ?? []` — empty while a new month loads, populated once data arrives
- Error state still replaces the body with an error message
- PageController stays attached across all month changes, fixing both symptoms from #24

## Root cause

`calendarDataProvider` watches `currentMonthProvider`. When `onPageChanged` fired, it updated `currentMonthProvider`, which invalidated the provider and put `calendarAsync` into `loading`. The old `body: calendarAsync.when(loading: () => CircularProgressIndicator())` unmounted the PageView, detaching the PageController. Any subsequent `animateToPage()` call threw `'positions.isNotEmpty'`.

Closes #24

## Test plan

- [ ] Tap the prev/next chevron repeatedly — navigation works freely with no freeze
- [ ] Swipe the PageView manually through several months — no exception in logs
- [ ] Dots appear on the new month after a brief moment (not a regression — previous behaviour showed a full-screen spinner instead)
- [ ] No regression on day sheet, add expense form, or other tabs